### PR TITLE
Fix 32bit build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern "system" {
 }
 
 #[no_mangle]
-unsafe extern "system" fn DllMain(hinst_dll: usize, fdw_reason: u32) -> isize {
+unsafe extern "system" fn DllMain(hinst_dll: usize, fdw_reason: u32, _reserved: usize) -> isize {
     match fdw_reason {
         1 => {
             std::thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@ use std::time::Duration;
 
 #[link(name = "kernel32")]
 extern "system" {
-    fn AllocConsole() -> i32;
-    fn FreeConsole() -> i32;
+    fn AllocConsole() -> isize;
+    fn FreeConsole() -> isize;
     fn FreeLibraryAndExitThread(h_module: usize, exit_code: u32) -> !;
 }
 
 #[no_mangle]
-unsafe extern "system" fn DllMain(hinst_dll: usize, fdw_reason: u32) -> i32 {
+unsafe extern "system" fn DllMain(hinst_dll: usize, fdw_reason: u32) -> isize {
     match fdw_reason {
         1 => {
             std::thread::spawn(move || {


### PR DESCRIPTION
The `DllMain` `reserved` field was missing, causing the 32bit build to fail.
Also, I used `isize` instead of fixed width integers, so the function definitions remain valid for 32 and 64 bit.